### PR TITLE
Fix: Install devDependencies in Docker builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /usr/src/app
 COPY package.json package-lock.json ./
 
 # Install dependencies
-# Using --omit=dev to not install devDependencies for production build stage
-RUN npm install --omit=dev
+# All dependencies (including devDependencies like Vite) are needed for the build
+RUN npm install
 
 # Copy the rest of the application source code
 COPY . .


### PR DESCRIPTION
- I removed `--omit=dev` from `npm install` in the Dockerfile's builder stage.
- This ensures Vite and other devDependencies are installed, allowing the `npm run build` command to succeed.

This addresses the "vite: not found" error during Coolify deployment.