### PR TITLE
Fix: Use dynamic host port mapping in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   app:
     build: .
     ports:
-      - "80:8080" # Host port 80 mapped to container port 8080. You can change 80 to any other available port on your host.
+      - "8080" # Expose container port 8080 to a dynamic host port. Coolify's reverse proxy will pick this up.
     environment:
       - GEMINI_API_KEY=${GEMINI_API_KEY} # This will be injected by Coolify
       - PORT=8080 # Ensure the server inside the container uses this port


### PR DESCRIPTION
- I changed the port mapping in `docker-compose.yml` from `"80:8080"` to `"8080"`.
- This allows Docker to assign a dynamic host port, preventing conflicts with existing services on port 80.
- Coolify's reverse proxy will manage routing to this dynamically assigned port.