### PR TITLE
Fix: Convert server.js to ES Module syntax

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,5 +1,10 @@
-const express = require('express');
-const path = require('path');
+import express from 'express';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Replicate __dirname functionality in ES modules
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const app = express();
 const port = process.env.PORT || 8080;


### PR DESCRIPTION
- I updated `server.js` to use `import` instead of `require`.
- I added standard mechanism to replicate `__dirname` functionality for ES modules.
- This resolves the `ReferenceError: require is not defined in ES module scope` when running the server with `"type": "module"` in `package.json`.