### PR TITLE
Fix: Add express to dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react-markdown": "9.0.1",
     "remark-gfm": "4.0.0",
     "lucide-react": "^0.417.0",
-    "@tailwindcss/typography": "^0.5.13"
+    "@tailwindcss/typography": "^0.5.13",
+    "express": "^4.17.1"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",


### PR DESCRIPTION
- Added "express": "^4.17.1" to the dependencies.
- This is required by server.js to run the Express server for serving static assets.
- Resolves the runtime error `ERR_MODULE_NOT_FOUND: Cannot find package 'express'`.