### PR TITLE
I've made some changes to `vite.config.ts` to help us understand how …

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,11 +2,35 @@ import path from 'path';
 import { defineConfig, loadEnv } from 'vite';
 
 export default defineConfig(({ mode }) => {
-    const env = loadEnv(mode, '.', '');
+    // Load .env files if any (though Coolify provides env vars directly)
+    const loadedEnv = loadEnv(mode, process.cwd(), '');
+
+    // Get GEMINI_API_KEY directly from the build process environment first,
+    // then fall back to what loadEnv found (if anything).
+    const coolifyProvidedApiKey = process.env.GEMINI_API_KEY;
+    const apiKeyFromLoadEnv = loadedEnv.GEMINI_API_KEY;
+
+    const apiKeyToUse = coolifyProvidedApiKey || apiKeyFromLoadEnv;
+
+    // Log for debugging during Coolify build
+    console.log(`[vite.config.ts] Debugging GEMINI_API_KEY:`);
+    console.log(`  - Directly from process.env.GEMINI_API_KEY: ${coolifyProvidedApiKey ? '****** (exists)' : 'Not found'}`);
+    console.log(`  - From loadEnv().GEMINI_API_KEY: ${apiKeyFromLoadEnv ? '****** (exists)' : 'Not found'}`);
+    console.log(`  - API Key being used for define: ${apiKeyToUse ? '****** (exists)' : 'Not found / Undefined'}`);
+    if (coolifyProvidedApiKey) {
+      console.log(`    Direct process.env.GEMINI_API_KEY length: ${coolifyProvidedApiKey.length}`);
+    }
+    if (apiKeyFromLoadEnv) {
+      console.log(`    loadEnv().GEMINI_API_KEY length: ${apiKeyFromLoadEnv.length}`);
+    }
+
+
     return {
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        // The key 'process.env.API_KEY' is what geminiService.ts uses
+        'process.env.API_KEY': JSON.stringify(apiKeyToUse),
+        // Also defining 'process.env.GEMINI_API_KEY' for completeness, though not directly used by geminiService.ts
+        'process.env.GEMINI_API_KEY': JSON.stringify(apiKeyToUse)
       },
       resolve: {
         alias: {


### PR DESCRIPTION
…the GEMINI_API_KEY is being handled.

- I updated `vite.config.ts` to log information about the GEMINI_API_KEY when the project is built.
- It will now check for the GEMINI_API_KEY directly in the build environment first, before looking elsewhere.
- This should help us see if the API key you set in Coolify is being picked up correctly by Vite during the build.